### PR TITLE
handling interval extraction event miss after initial run. 

### DIFF
--- a/interval.coffee
+++ b/interval.coffee
@@ -27,7 +27,7 @@ class IntervalScheduler extends Base
  _nextTime: -> null
  _lastTime: -> null
 
- @listen 'check', ->
+#  @listen 'check', ->
 
 module.exports = (Types) ->
  Types.interval = IntervalScheduler


### PR DESCRIPTION
Example use case: 
If the plugin interval is set for 10 minutes and the initial extraction takes more than that, then the interval extraction does not start after the initial run is complete unless the plugin service is manually restarted. This commit comments out the override of the base class function. 